### PR TITLE
fix ranges encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## Unreleased
 
-[Compare with 0.6.0](https://github.com/edgedb/edgedb-elixir/compare/v0.6.0...HEAD)
+[Compare with 0.6.1](https://github.com/edgedb/edgedb-elixir/compare/v0.6.1...HEAD)
+
+## [0.6.1] - 2023-07-07
+
+[Compare with 0.6.0](https://github.com/edgedb/edgedb-elixir/compare/v0.6.0...v0.6.1)
 
 ### Added
 
 - support for `Elixir v1.15` and `Erlang/OTP 26`.
+
+### Fixed
+
+- encoding of `t:EdgeDB.Range.t/0` values.
+- constructing `t:EdgeDB.Range.t/0` from `EdgeDB.Range.new/3` with `nil` as values.
+- examples in the documentation and the `Inspect` implementation of
+    `t:EdgeDB.DateDuration.t/0` and `t:EdgeDB.Range.t/0`.
 
 ## [0.6.0] - 2023-06-22
 

--- a/lib/edgedb/types/date_duration.ex
+++ b/lib/edgedb/types/date_duration.ex
@@ -6,7 +6,7 @@ defmodule EdgeDB.DateDuration do
   ```elixir
   iex(1)> {:ok, client} = EdgeDB.start_link()
   iex(2)> EdgeDB.query_required_single!(client, "select <cal::date_duration>'1 year 2 days'")
-  #EdgeDB.Duration<"P1Y20D">
+  #EdgeDB.DateDuration<"P1Y2D">
   ```
   """
 
@@ -33,12 +33,12 @@ defimpl Inspect, for: EdgeDB.DateDuration do
 
   @impl Inspect
   def inspect(%EdgeDB.DateDuration{days: 0, months: 0}, _opts) do
-    concat(["#EdgeDB.RelativeDuration<\"", "P0D", "\">"])
+    concat(["#EdgeDB.DateDuration<\"", "P0D", "\">"])
   end
 
   @impl Inspect
   def inspect(%EdgeDB.DateDuration{} = duration, _opts) do
-    concat(["#EdgeDB.RelativeDuration<\"", format_date("P", duration), "\">"])
+    concat(["#EdgeDB.DateDuration<\"", format_date("P", duration), "\">"])
   end
 
   defp format_date(formatted_repr, %EdgeDB.DateDuration{} = duration) do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule EdgeDB.MixProject do
   use Mix.Project
 
   @app :edgedb
-  @version "0.6.0"
+  @version "0.6.1"
   @source_url "https://github.com/edgedb/edgedb-elixir"
   @description "EdgeDB client for Elixir"
 

--- a/test/docs/docs_test.exs
+++ b/test/docs/docs_test.exs
@@ -19,6 +19,12 @@ defmodule Tests.DocsTest do
   doctest EdgeDB.RelativeDuration
   doctest EdgeDB.Set
 
+  skip_before(version: 2)
+  doctest EdgeDB.DateDuration
+
+  skip_before(version: 2)
+  doctest EdgeDB.Range
+
   defp drop_tickets(client) do
     EdgeDB.query!(client, "delete Ticket")
 


### PR DESCRIPTION
It turned out that ranges encoding didn't work correctly after implementing them in the client because of bug in tests. This PR fixes the error and ensures docs for `EdgeDB.DateDuration` and `EdgeDB.Range` are being tested as well 